### PR TITLE
Batch update accounts with new owner on deactivation

### DIFF
--- a/force-app/main/default/classes/DeactivatedOwnerAccountReassignmentBatch.cls
+++ b/force-app/main/default/classes/DeactivatedOwnerAccountReassignmentBatch.cls
@@ -1,0 +1,161 @@
+global without sharing class DeactivatedOwnerAccountReassignmentBatch implements Database.Batchable<SObject>, Database.Stateful {
+
+	private Id defaultOwnerId;
+	private Set<Id> ownerIdsToProcess;
+	private static final Integer MAX_RETRIES = 3;
+
+	public DeactivatedOwnerAccountReassignmentBatch(Id defaultOwnerIdParam) {
+		this.defaultOwnerId = defaultOwnerIdParam;
+		this.ownerIdsToProcess = null;
+	}
+
+	public DeactivatedOwnerAccountReassignmentBatch(Id defaultOwnerIdParam, Set<Id> ownerIdsToProcessParam) {
+		this.defaultOwnerId = defaultOwnerIdParam;
+		this.ownerIdsToProcess = ownerIdsToProcessParam;
+	}
+
+	global Database.QueryLocator start(Database.BatchableContext bc) {
+		if (this.defaultOwnerId == null) {
+			this.defaultOwnerId = resolveDefaultOwnerId();
+		}
+
+		if (this.defaultOwnerId == null) {
+			// No default owner could be resolved; return empty locator to safely exit without processing
+			return Database.getQueryLocator('SELECT Id FROM Account WHERE Id = null');
+		}
+
+		String query = 'SELECT Id, OwnerId FROM Account WHERE OwnerId IN (SELECT Id FROM User WHERE IsActive = false)';
+		if (ownerIdsToProcess != null && !ownerIdsToProcess.isEmpty()) {
+			query += ' AND OwnerId IN :ownerIdsToProcess';
+		}
+		query += ' AND OwnerId != :defaultOwnerId ORDER BY Id';
+		return Database.getQueryLocator(query);
+	}
+
+	global void execute(Database.BatchableContext bc, List<SObject> scope) {
+		if (scope.isEmpty()) {
+			return;
+		}
+
+		List<Account> accountsToUpdate = new List<Account>();
+		for (SObject s : scope) {
+			Account accountFromScope = (Account) s;
+			if (accountFromScope.OwnerId != this.defaultOwnerId) {
+				accountsToUpdate.add(new Account(Id = accountFromScope.Id, OwnerId = this.defaultOwnerId));
+			}
+		}
+
+		if (accountsToUpdate.isEmpty()) {
+			return;
+		}
+
+		attemptUpdateWithRetry(accountsToUpdate);
+	}
+
+	global void finish(Database.BatchableContext bc) {
+		// No-op; extend to add summary notifications if required
+	}
+
+	private static Id resolveDefaultOwnerId() {
+		// Attempt to resolve from Custom Metadata (Owner_Default__mdt.Account_Default_Owner__c)
+		try {
+			List<SObject> cmdSettings = Database.query('SELECT Account_Default_Owner__c FROM Owner_Default__mdt LIMIT 1');
+			if (!cmdSettings.isEmpty()) {
+				Object valueFromCmd = cmdSettings[0].get('Account_Default_Owner__c');
+				if (valueFromCmd != null) {
+					return (Id) valueFromCmd;
+				}
+			}
+		} catch (Exception ignoreCmd) {
+			// Safe to ignore; org may not have this metadata
+		}
+
+		// Attempt to resolve from Custom Setting (Automation_Settings__c.Default_Account_Owner__c)
+		try {
+			List<SObject> csSettings = Database.query('SELECT Default_Account_Owner__c FROM Automation_Settings__c LIMIT 1');
+			if (!csSettings.isEmpty()) {
+				Object valueFromCs = csSettings[0].get('Default_Account_Owner__c');
+				if (valueFromCs != null) {
+					return (Id) valueFromCs;
+				}
+			}
+		} catch (Exception ignoreCs) {
+			// Safe to ignore; org may not have this setting
+		}
+
+		return null;
+	}
+
+	private void attemptUpdateWithRetry(List<Account> accountsToUpdate) {
+		List<Account> remainingToUpdate = new List<Account>(accountsToUpdate);
+		Integer attemptIndex = 0;
+		while (!remainingToUpdate.isEmpty() && attemptIndex < MAX_RETRIES) {
+			attemptIndex++;
+			Database.SaveResult[] updateResults = Database.update(remainingToUpdate, false);
+			List<Account> lockRetryRecords = new List<Account>();
+			for (Integer i = 0; i < updateResults.size(); i++) {
+				Database.SaveResult sr = updateResults[i];
+				Account accountAttempted = remainingToUpdate[i];
+				if (!sr.isSuccess()) {
+					Boolean hasOnlyLockErrors = true;
+					String combinedErrorMessage = '';
+					for (Database.Error err : sr.getErrors()) {
+						combinedErrorMessage += (combinedErrorMessage == '' ? '' : ' | ') + String.valueOf(err.getStatusCode()) + ': ' + err.getMessage();
+						if (err.getStatusCode() != StatusCode.UNABLE_TO_LOCK_ROW) {
+							hasOnlyLockErrors = false;
+						}
+					}
+					if (hasOnlyLockErrors && attemptIndex < MAX_RETRIES) {
+						lockRetryRecords.add(accountAttempted);
+					} else {
+						logExceptionForAccount(accountAttempted.Id, combinedErrorMessage);
+					}
+				}
+			}
+			remainingToUpdate = lockRetryRecords;
+		}
+		// After exhausting retries, any remaining records are logged as lock failures
+		for (Account acc : remainingToUpdate) {
+			logExceptionForAccount(acc.Id, 'UNABLE_TO_LOCK_ROW: Could not update after ' + String.valueOf(MAX_RETRIES) + ' attempts');
+		}
+	}
+
+	private static void logExceptionForAccount(Id accountId, String errorMessage) {
+		try {
+			Schema.SObjectType exceptionLogType = Schema.getGlobalDescribe().get('Exception_Log__c');
+			if (exceptionLogType == null) {
+				return; // Log object not present in org
+			}
+
+			Schema.DescribeSObjectResult describeResult = exceptionLogType.getDescribe();
+			Map<String, Schema.SObjectField> fieldMap = describeResult.fields.getMap();
+			SObject logRecord = exceptionLogType.newSObject();
+
+			if (fieldMap.containsKey('Name')) {
+				logRecord.put('Name', 'AccountOwnerReassign ' + String.valueOf(accountId));
+			}
+			if (fieldMap.containsKey('Record_Id__c')) {
+				logRecord.put('Record_Id__c', accountId);
+			}
+			if (fieldMap.containsKey('Related_Record_Id__c')) {
+				logRecord.put('Related_Record_Id__c', accountId);
+			}
+			if (fieldMap.containsKey('SObject_Type__c')) {
+				logRecord.put('SObject_Type__c', 'Account');
+			}
+			if (fieldMap.containsKey('Context__c')) {
+				logRecord.put('Context__c', 'DeactivatedOwnerAccountReassignmentBatch');
+			}
+			if (fieldMap.containsKey('Error_Message__c')) {
+				logRecord.put('Error_Message__c', errorMessage);
+			} else if (fieldMap.containsKey('Message__c')) {
+				logRecord.put('Message__c', errorMessage);
+			}
+
+			Database.insert(logRecord, false);
+		} catch (Exception ignore) {
+			// Swallow all exceptions during logging; avoid failing the batch due to logging
+		}
+	}
+}
+

--- a/force-app/main/default/classes/DeactivatedOwnerAccountReassignmentBatch.cls-meta.xml
+++ b/force-app/main/default/classes/DeactivatedOwnerAccountReassignmentBatch.cls-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+    
+</ApexClass>
+

--- a/force-app/main/default/classes/DeactivatedOwnerAccountReassignmentBatch_TEST.cls
+++ b/force-app/main/default/classes/DeactivatedOwnerAccountReassignmentBatch_TEST.cls
@@ -1,0 +1,71 @@
+@IsTest
+private class DeactivatedOwnerAccountReassignmentBatch_TEST {
+
+	private static Profile getAnyStandardProfile() {
+		return [SELECT Id FROM Profile WHERE UserType = 'Standard' LIMIT 1];
+	}
+
+	private static User createActiveUser(String uniqueAlias) {
+		Profile standardProfile = getAnyStandardProfile();
+		User newUserRecord = new User(
+			Alias = uniqueAlias.left(8),
+			Email = uniqueAlias + '@example.com',
+			EmailEncodingKey = 'UTF-8',
+			LastName = uniqueAlias,
+			LanguageLocaleKey = 'en_US',
+			LocaleSidKey = 'en_US',
+			TimeZoneSidKey = 'America/Los_Angeles',
+			ProfileId = standardProfile.Id,
+			Username = uniqueAlias + '+' + System.currentTimeMillis() + '@example.com'
+		);
+		insert newUserRecord;
+		return newUserRecord;
+	}
+
+	@IsTest
+	static void testReassignmentFromDeactivatedOwner() {
+		User oldOwnerUser = createActiveUser('oldowner1');
+		User defaultOwnerUser = createActiveUser('newowner1');
+
+		Account accOne = new Account(Name = 'Test A1', OwnerId = oldOwnerUser.Id);
+		Account accTwo = new Account(Name = 'Test A2', OwnerId = oldOwnerUser.Id);
+		insert new List<Account>{ accOne, accTwo };
+
+		// Deactivate the old owner user
+		System.runAs(defaultOwnerUser) {
+			oldOwnerUser.IsActive = false;
+			update oldOwnerUser;
+		}
+
+		Test.startTest();
+		Database.executeBatch(new DeactivatedOwnerAccountReassignmentBatch(defaultOwnerUser.Id), 50);
+		Test.stopTest();
+
+		List<Account> updatedAccounts = [SELECT Id, OwnerId FROM Account WHERE Id IN :new List<Id>{ accOne.Id, accTwo.Id }];
+		for (Account updatedAccount : updatedAccounts) {
+			System.assertEquals(defaultOwnerUser.Id, updatedAccount.OwnerId, 'Owner should be reassigned to default owner');
+		}
+	}
+
+	@IsTest
+	static void testUserTriggerLaunchesBatch() {
+		User oldOwnerUser = createActiveUser('oldowner2');
+		User defaultOwnerUser = createActiveUser('newowner2');
+
+		insert new Account(Name = 'FromTrigger', OwnerId = oldOwnerUser.Id);
+
+		// Deactivate via update to fire trigger
+		System.runAs(defaultOwnerUser) {
+			oldOwnerUser.IsActive = false;
+			update oldOwnerUser;
+		}
+
+		Test.startTest();
+		// Trigger should enqueue batch; stopTest will run it
+		Test.stopTest();
+
+		Integer reassigned = [SELECT COUNT() FROM Account WHERE OwnerId = :defaultOwnerUser.Id];
+		System.assert(reassigned > 0, 'Accounts should be reassigned by trigger-launched batch');
+	}
+}
+

--- a/force-app/main/default/classes/DeactivatedOwnerAccountReassignmentBatch_TEST.cls-meta.xml
+++ b/force-app/main/default/classes/DeactivatedOwnerAccountReassignmentBatch_TEST.cls-meta.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+    
+</ApexClass>
+

--- a/force-app/main/default/classes/UserTriggerHandler.cls
+++ b/force-app/main/default/classes/UserTriggerHandler.cls
@@ -1,0 +1,16 @@
+public without sharing class UserTriggerHandler {
+
+	public static void onAfterUpdate(List<User> newList, Map<Id, User> oldMap) {
+		Set<Id> deactivatedUserIds = new Set<Id>();
+		for (User u : newList) {
+			User oldRecord = oldMap.get(u.Id);
+			if (oldRecord != null && oldRecord.IsActive == true && u.IsActive == false) {
+				deactivatedUserIds.add(u.Id);
+			}
+		}
+		if (!deactivatedUserIds.isEmpty()) {
+			Database.executeBatch(new DeactivatedOwnerAccountReassignmentBatch(null, deactivatedUserIds), 200);
+		}
+	}
+}
+

--- a/force-app/main/default/classes/UserTriggerHandler.cls-meta.xml
+++ b/force-app/main/default/classes/UserTriggerHandler.cls-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+

--- a/force-app/main/default/triggers/UserTrigger.trigger
+++ b/force-app/main/default/triggers/UserTrigger.trigger
@@ -1,0 +1,6 @@
+trigger UserTrigger on User (after update) {
+	if (Trigger.isAfter && Trigger.isUpdate) {
+		UserTriggerHandler.onAfterUpdate(Trigger.new, Trigger.oldMap);
+	}
+}
+

--- a/force-app/main/default/triggers/UserTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/UserTrigger.trigger-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>60.0</apiVersion>
+    <status>Active</status>
+</ApexTrigger>
+


### PR DESCRIPTION
### What does this PR do?
This PR implements an automated solution to reassign Account records when their owner is deactivated. It uses Batch Apex to handle bulk reassignments, incorporates retry logic for `UNABLE_TO_LOCK_ROW` errors, and logs any unresolvable issues to a custom `Exception_Log__c` object. A `User` trigger initiates this batch process automatically upon user deactivation.

### What issues does this PR fix or reference?

#<Insert GitHub Issue>

## The PR fulfills these requirements:

[x] Tests for the proposed changes have been added/updated.
[ ] Code linting and formatting was performed.

### Functionality Before

When an Account owner was deactivated, their owned Account records remained assigned to the deactivated user. There was no automated process for reassignment, handling of record lock errors, or logging of exceptions.

### Functionality After

Upon deactivation of a User, a `User` trigger (`UserTrigger`) invokes a handler (`UserTriggerHandler`) which enqueues a Batch Apex job (`DeactivatedOwnerAccountReassignmentBatch`). This batch job performs the following:
- Identifies Accounts owned by the deactivated user(s).
- Reassigns these Accounts to a default owner, which is resolved dynamically from `Owner_Default__mdt.Account_Default_Owner__c`, `Automation_Settings__c.Default_Account_Owner__c`, or an explicitly provided ID.
- Attempts to update records with up to 3 retries if an `UNABLE_TO_LOCK_ROW` error occurs.
- Logs any final update failures (including persistent lock errors) to a dynamically detected `Exception_Log__c` custom object, including the Account ID and error message.

---
<a href="https://cursor.com/background-agent?bcId=bc-911bffbf-42b2-4a6d-8b21-812d7e91d530">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-911bffbf-42b2-4a6d-8b21-812d7e91d530">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

